### PR TITLE
Bump shelf dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: shelf_cors
-version: 0.2.1
+version: 0.2.2
 author: George Moschovitis <george.moschovitis@gmail.com>
 description: Middleware to add CORS headers to shelf responses.
 homepage: https://github.com/gmosx/dart-shelf_cors
 dependencies:
-  shelf: '>=0.6.1 <0.7.0'
+  shelf: '>=0.6.1 <0.8.0'
 dev_dependencies:
   unittest: any


### PR DESCRIPTION
Hi,

Newer versions of Dart 2.0 SDK require a shelf version > 0.7.0.  Can you publish a new version of the package with this updated dependency?  The unit tests seem to pass with the latest shelf.